### PR TITLE
chore: Add Splash screen and Redux store configuration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,8 @@ import Router from "@/Router/Router";
 import { StatusBar } from "expo-status-bar";
 import { StyleSheet, View } from "react-native";
 import { useFonts } from "expo-font";
+import { Provider } from "react-redux";
+import { store } from "@/Store";
 
 export default function App() {
   const [loaded] = useFonts({
@@ -18,10 +20,12 @@ export default function App() {
   }
   return (
     <>
-      <View style={styles.container}>
-        <StatusBar style="auto" />
-        <Router />
-      </View>
+      <Provider store={store}>
+        <View style={styles.container}>
+          <StatusBar style="auto" />
+          <Router />
+        </View>
+      </Provider>
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,21 @@
       "name": "rick_and_morty",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "1.23.1",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
+        "@reduxjs/toolkit": "^2.2.5",
+        "axios": "^1.7.1",
         "expo": "~51.0.8",
         "expo-font": "~12.0.5",
         "expo-status-bar": "~1.12.1",
+        "lottie-react-native": "6.7.0",
         "react": "18.2.0",
         "react-native": "0.74.1",
         "react-native-safe-area-context": "4.10.1",
-        "react-native-screens": "3.31.1"
+        "react-native-screens": "3.31.1",
+        "react-redux": "^9.1.2",
+        "redux": "^5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -3560,6 +3566,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
+      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "13.6.6",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.6.tgz",
@@ -5514,6 +5531,29 @@
         "nanoid": "^3.1.23"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.5.tgz",
+      "integrity": "sha512-aeFA/s5NCG7NoJe/MhmwREJxRkDs0ZaSqt0MxhWUrwCf1UQXpwR87RROJEql0uAkLI6U7snBOYOcKw83ew3FPg==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rnx-kit/chromium-edge-launcher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
@@ -5671,6 +5711,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -5971,6 +6016,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
+      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-core": {
@@ -7779,6 +7847,25 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
@@ -8318,6 +8405,15 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -8655,6 +8751,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "engines": {
         "node": ">=8"
       }
@@ -9871,6 +9975,29 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lottie-react-native": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-6.7.0.tgz",
+      "integrity": "sha512-doiF/36LaKkzo0XkgUIK8egxALNY6jGjCI4szpRuwop15LTW3DFtIA2L3pusNdaH7oM797aSH5UylIJw2k+Hgw==",
+      "peerDependencies": {
+        "@dotlottie/react-player": "^1.6.1",
+        "@lottiefiles/react-lottie-player": "^3.5.3",
+        "react": "*",
+        "react-native": ">=0.46",
+        "react-native-windows": ">=0.63.x"
+      },
+      "peerDependenciesMeta": {
+        "@dotlottie/react-player": {
+          "optional": true
+        },
+        "@lottiefiles/react-lottie-player": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9950,6 +10077,17 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -11468,6 +11606,11 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -11790,6 +11933,28 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -11849,6 +12014,19 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -11979,6 +12157,11 @@
       "dependencies": {
         "path-parse": "^1.0.5"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -13398,6 +13581,14 @@
       "integrity": "sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,21 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
+    "@reduxjs/toolkit": "^2.2.5",
+    "axios": "^1.7.1",
     "expo": "~51.0.8",
+    "expo-font": "~12.0.5",
     "expo-status-bar": "~1.12.1",
+    "lottie-react-native": "6.7.0",
     "react": "18.2.0",
     "react-native": "0.74.1",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
-    "expo-font": "~12.0.5"
+    "react-redux": "^9.1.2",
+    "redux": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,0 +1,93 @@
+import axios, { AxiosRequestConfig, AxiosError } from "axios";
+
+const BASE_URL = "https://rickandmortyapi.com/api";
+
+type Packet =
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | Record<string, unknown>
+  | FormData;
+
+type Response<T> = {
+  statusCode: string | null;
+  data: T | null;
+};
+
+const DEFAULT_TIMEOUT = 60000;
+
+const Config: AxiosRequestConfig = {
+  baseURL: BASE_URL,
+  timeout: DEFAULT_TIMEOUT,
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: null,
+  },
+};
+
+async function GET<T>(
+  url: string,
+  params?: Record<string, unknown>
+): Promise<Response<T>> {
+  try {
+    const controller = new AbortController();
+    Config.signal = controller.signal;
+    Config.params = params;
+    const response = await axios.get<T>(`${BASE_URL}${url}`, Config);
+    return {
+      statusCode: response.status.toString(),
+      data: response.data,
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const axiosError: AxiosError = error;
+      return {
+        statusCode: axiosError.response?.status.toString() || ("500" as string),
+        data: null,
+      };
+    } else {
+      return {
+        statusCode: "500" as string,
+        data: null,
+      };
+    }
+  }
+}
+
+async function POST<T>(
+  url: string,
+  data: Packet | FormData,
+  isFormData?: boolean
+): Promise<Response<T>> {
+  try {
+    const controller = new AbortController();
+    Config.signal = controller.signal;
+    if (isFormData) {
+      console.log("content-type", "multipart/form-data");
+      Config.headers!["Content-Type"] = "multipart/form-data";
+    } else {
+      Config.headers!["Content-Type"] = "application/json";
+    }
+    const response = await axios.post<T>(`${BASE_URL}${url}`, data, Config);
+    return {
+      statusCode: response.status.toString(),
+      data: response.data,
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const axiosError: AxiosError = error;
+      return {
+        statusCode: axiosError.response?.status.toString() || ("500" as string),
+        data: null,
+      };
+    } else {
+      return {
+        statusCode: "500" as string,
+        data: null,
+      };
+    }
+  }
+}
+
+export default { GET, POST };

--- a/src/Components/Card/Card.tsx
+++ b/src/Components/Card/Card.tsx
@@ -5,12 +5,18 @@ import MyText from "../MyText/MyText";
 import { styles } from "./Card.styles";
 
 const Card = (props: CardProps) => {
-  const { episode, season, airDate } = props;
+  const { episode, season, airDate, onPress } = props;
+
+  const handleOnPress = async () => {
+    if (onPress) {
+      await onPress();
+    }
+  };
 
   return (
     <>
       <View style={styles.body}>
-        <Pressable onPress={() => console.debug("click")}>
+        <Pressable onPress={() => handleOnPress()}>
           <MyText
             text="Episode: "
             size="header"

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { RouterProps } from "./Index";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { Home } from "@/Screens/index";
+import { Home, Splash } from "@/Screens/index";
 
 const Stack = createNativeStackNavigator();
 
@@ -11,6 +11,11 @@ const Router = (props: RouterProps) => {
     <>
       <NavigationContainer>
         <Stack.Navigator>
+          <Stack.Screen
+            name="Splash"
+            component={Splash}
+            options={{ headerShown: false }}
+          />
           <Stack.Screen name="Home" component={Home} />
         </Stack.Navigator>
       </NavigationContainer>

--- a/src/Screens/Home/Home.tsx
+++ b/src/Screens/Home/Home.tsx
@@ -2,8 +2,17 @@ import React from "react";
 import { HomeProps } from "./Index";
 import { View } from "react-native";
 import { Card, MyText } from "@/Components";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "@/Store";
+import { getEpisodes } from "@/Store/Slices/EpisodeSlice";
 
 const Home = (props: HomeProps) => {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const fetchEpisodes = () => {
+    dispatch(getEpisodes());
+  };
+
   return (
     <>
       <View>
@@ -11,7 +20,7 @@ const Home = (props: HomeProps) => {
           episode="Pilot"
           season="1"
           airDate="2021-07-01"
-          onPress={() => console.debug("click")}
+          onPress={() => fetchEpisodes()}
         />
       </View>
     </>

--- a/src/Screens/Splash/Index.d.ts
+++ b/src/Screens/Splash/Index.d.ts
@@ -1,0 +1,3 @@
+export type SplashProps = {
+  navigation: any;
+};

--- a/src/Screens/Splash/Splash.style.tsx
+++ b/src/Screens/Splash/Splash.style.tsx
@@ -1,0 +1,8 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  lottie: {
+    width: "100%",
+    height: "90%",
+  },
+});

--- a/src/Screens/Splash/Splash.tsx
+++ b/src/Screens/Splash/Splash.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from "react";
+import { SplashProps } from "./Index";
+import { View } from "react-native";
+import { MyText } from "@/Components";
+import LottieView from "lottie-react-native";
+import { styles } from "./Splash.style";
+
+const Splash = (props: SplashProps) => {
+  const { navigation } = props;
+
+  const Start = () => {
+    setTimeout(() => {
+      navigation.replace("Home");
+    }, 3000);
+  };
+  useEffect(() => {
+    Start();
+  }, []);
+
+  return (
+    <>
+      <LottieView
+        source={require("@/Assets/Animations/Rick.json")}
+        autoPlay
+        loop
+        style={styles.lottie}
+        speed={0.8}
+        resizeMode="contain"
+      />
+      <MyText
+        text="Loading.."
+        size="large"
+        type="bold"
+        verAlign="center"
+        horAlign="center"
+      />
+    </>
+  );
+};
+
+export default Splash;

--- a/src/Screens/index.ts
+++ b/src/Screens/index.ts
@@ -1,3 +1,4 @@
 import Home from "./Home/Home";
+import Splash from "./Splash/Splash";
 
-export { Home };
+export { Home, Splash };

--- a/src/Store/Slices/EpisodeSlice.ts
+++ b/src/Store/Slices/EpisodeSlice.ts
@@ -1,0 +1,44 @@
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../index";
+import { Episodes } from "../types/Episode";
+import API from "@/Api";
+
+export const getEpisodes = createAsyncThunk("episode/getEpisodes", async () => {
+  const response = await API.GET<Episodes | null>("/episode");
+  console.log("response", response.data);
+  return response.data;
+});
+
+export const episodeSlice = createSlice({
+  name: "episode",
+  initialState: {
+    episodes: null as Episodes | null,
+    loading: false as boolean,
+    error: undefined as string | undefined,
+  },
+  reducers: {
+    setEpisodes: (state, action) => {
+      state.episodes = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getEpisodes.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(
+      getEpisodes.fulfilled,
+      (state, action: PayloadAction<Episodes | null>) => {
+        state.loading = false;
+        state.episodes = action.payload;
+      }
+    );
+    builder.addCase(getEpisodes.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.error.message;
+    });
+  },
+});
+
+export const {} = episodeSlice.actions;
+
+export default episodeSlice.reducer;

--- a/src/Store/index.ts
+++ b/src/Store/index.ts
@@ -1,1 +1,19 @@
-export default {};
+import { configureStore, ThunkAction, Action } from "@reduxjs/toolkit";
+import episodeReducer from "./Slices/EpisodeSlice";
+
+export const store = configureStore({
+  reducer: {
+    episode: episodeReducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>;

--- a/src/Store/types/Episode.d.ts
+++ b/src/Store/types/Episode.d.ts
@@ -1,0 +1,21 @@
+export interface Episodes {
+  info: Info;
+  results: Result[];
+}
+
+export interface Info {
+  count: number;
+  pages: number;
+  next: string;
+  prev: any;
+}
+
+export interface Result {
+  id: number;
+  name: string;
+  air_date: string;
+  episode: string;
+  characters: string[];
+  url: string;
+  created: string;
+}


### PR DESCRIPTION
This commit adds the `Splash` screen to the `Screens` directory and updates the `Router` component to include the `Splash` screen as the initial screen. Additionally, the Redux store configuration is updated in the `Store/index.ts` file to include the `episodeReducer` slice. This change ensures that the application displays a splash screen on startup and sets up the Redux store for managing episode data.